### PR TITLE
Handle hidden values and Preview links better

### DIFF
--- a/Classes/Domain/Repository/ShortNrRepository.php
+++ b/Classes/Domain/Repository/ShortNrRepository.php
@@ -44,6 +44,10 @@ class ShortNrRepository
         }
 
         $qb = $this->getQueryBuilder($tableName);
+        $qb->getRestrictions()
+            ->removeByType(HiddenRestriction::class)
+            ->removeByType(StartTimeRestriction::class)
+            ->removeByType(EndTimeRestriction::class);
         $qb->select(...$existingValidFields);
         $qb->from($tableName);
 
@@ -82,6 +86,10 @@ class ShortNrRepository
         }
 
         $qb = $this->getQueryBuilder($tableName);
+        $qb->getRestrictions()
+            ->removeByType(HiddenRestriction::class)
+            ->removeByType(StartTimeRestriction::class)
+            ->removeByType(EndTimeRestriction::class);
         $qb->select(...$existingValidFields);
         $qb->from($tableName);
         $qb->where(
@@ -164,6 +172,10 @@ class ShortNrRepository
     private function fetchRowForLanguageUidBase(string $table, array $fields, string $uidField, string $languageParentField, int $uid): array
     {
         $qb = $this->getQueryBuilder($table);
+        $qb->getRestrictions()
+            ->removeByType(HiddenRestriction::class)
+            ->removeByType(StartTimeRestriction::class)
+            ->removeByType(EndTimeRestriction::class);
         $qb->select(...$fields)
             ->from($table)
             ->where(

--- a/Classes/Service/EncoderService.php
+++ b/Classes/Service/EncoderService.php
@@ -22,6 +22,11 @@ class EncoderService extends AbstractUrlService
      */
     public function encode(EncoderDemandInterface $demand): ?string
     {
+        // be_user session detected, auto disable cache
+        if ($GLOBALS['BE_USER']?->user !== null) {
+            $demand->setNoCache(true);
+        }
+
         if ($demand->noCache() || ($cacheKey = $demand->getCacheKey()) === null) {
             return $this->encodeWithDemand($demand);
         }


### PR DESCRIPTION
This PR disable encode caching as soon a active be_user session is detected.

it also include hidden records (pages, news, etc). into the entire decoding/encoding process to enhance the preview capabilities, there is no exposure of hidden information since these records itself are still hidden on typo3 and therefore not accesable in the frontend in the first place (except an active BE_USER session exists)